### PR TITLE
Span issue 9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@ Version 0.11.0
 
 Released on April XX, 2019
 
+- If the model file is present, Span can now call and tune peaks with no further options required
+- If the options are nevertheless provided, they're checked against those stored in the model file
+- Span recognizes explicit options `--fragment auto` and `--keep-dup false` (previously, the user had to
+omit the options to achieve this result)
 - Reduced statistical data model convergence time
 - Changed model initial point
 - Safeguards against NB parameters vanishing for small signal-to-noise ratio or insufficient number of reads

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanDifferentialPeakCallingExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanDifferentialPeakCallingExperiment.kt
@@ -57,7 +57,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
             reduceIds(paths1.flatMap { listOfNotNull(it.first, it.second) }.map { it.stemGz } +
                     listOf("vs") +
                     paths2.flatMap { listOfNotNull(it.first, it.second) }.map { it.stemGz }
-                    + listOfNotNull(fragment, binSize).map { it.toString() })
+                    + listOfNotNull(fragment.orElse(null), binSize).map { it.toString() })
 
 
     fun computeDirectedDifferencePeaks(fdr: Double,

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanDifferentialPeakCallingExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanDifferentialPeakCallingExperiment.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.bio.experiments.fit
 
+import org.jetbrains.bio.coverage.AutoFragment
+import org.jetbrains.bio.coverage.Fragment
 import org.jetbrains.bio.dataframe.DataFrame
 import org.jetbrains.bio.genome.GenomeQuery
 import org.jetbrains.bio.genome.containers.genomeMap
@@ -15,7 +17,6 @@ import org.jetbrains.bio.statistics.hmm.MLConstrainedNBHMM
 import org.jetbrains.bio.statistics.hypothesis.NullHypothesis
 import org.jetbrains.bio.statistics.state.ZLHID
 import java.nio.file.Path
-import java.util.*
 
 /**
  * @author Alexey Dievsky
@@ -25,7 +26,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
         genomeQuery: GenomeQuery,
         paths1: List<Pair<Path, Path?>>,
         paths2: List<Pair<Path, Path?>>,
-        fragment: Optional<Int>,
+        fragment: Fragment,
         binSize: Int,
         modelFitter: Fitter<Model>,
         modelClass: Class<Model>,
@@ -43,7 +44,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
             genomeQuery: GenomeQuery,
             paths1: Pair<Path, Path?>,
             paths2: Pair<Path, Path?>,
-            fragment: Optional<Int>, binSize: Int,
+            fragment: Fragment, binSize: Int,
             modelFitter: Fitter<Model>,
             modelClass: Class<Model>,
             states: Array<State>, nullHypothesis: NullHypothesis<State>
@@ -57,7 +58,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
             reduceIds(paths1.flatMap { listOfNotNull(it.first, it.second) }.map { it.stemGz } +
                     listOf("vs") +
                     paths2.flatMap { listOfNotNull(it.first, it.second) }.map { it.stemGz }
-                    + listOfNotNull(fragment.orElse(null), binSize).map { it.toString() })
+                    + listOfNotNull(fragment.nullableInt, binSize).map { it.toString() })
 
 
     fun computeDirectedDifferencePeaks(fdr: Double,
@@ -97,7 +98,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
                 paths1: List<Pair<Path, Path?>>,
                 paths2: List<Pair<Path, Path?>>,
                 bin: Int,
-                fragment: Optional<Int> = Optional.empty()
+                fragment: Fragment = AutoFragment
         ): SpanDifferentialPeakCallingExperiment<MLConstrainedNBHMM, ZLHID> {
             check(paths1.isNotEmpty() && paths2.isNotEmpty()) { "No data" }
             return if (paths1.size == 1 && paths2.size == 1) {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanDifferentialPeakCallingExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanDifferentialPeakCallingExperiment.kt
@@ -15,6 +15,7 @@ import org.jetbrains.bio.statistics.hmm.MLConstrainedNBHMM
 import org.jetbrains.bio.statistics.hypothesis.NullHypothesis
 import org.jetbrains.bio.statistics.state.ZLHID
 import java.nio.file.Path
+import java.util.*
 
 /**
  * @author Alexey Dievsky
@@ -24,7 +25,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
         genomeQuery: GenomeQuery,
         paths1: List<Pair<Path, Path?>>,
         paths2: List<Pair<Path, Path?>>,
-        fragment: Int?,
+        fragment: Optional<Int>,
         binSize: Int,
         modelFitter: Fitter<Model>,
         modelClass: Class<Model>,
@@ -42,7 +43,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
             genomeQuery: GenomeQuery,
             paths1: Pair<Path, Path?>,
             paths2: Pair<Path, Path?>,
-            fragment: Int?, binSize: Int,
+            fragment: Optional<Int>, binSize: Int,
             modelFitter: Fitter<Model>,
             modelClass: Class<Model>,
             states: Array<State>, nullHypothesis: NullHypothesis<State>
@@ -96,7 +97,7 @@ class SpanDifferentialPeakCallingExperiment<Model : ClassificationModel, State :
                 paths1: List<Pair<Path, Path?>>,
                 paths2: List<Pair<Path, Path?>>,
                 bin: Int,
-                fragment: Int? = null
+                fragment: Optional<Int> = Optional.empty()
         ): SpanDifferentialPeakCallingExperiment<MLConstrainedNBHMM, ZLHID> {
             check(paths1.isNotEmpty() && paths2.isNotEmpty()) { "No data" }
             return if (paths1.size == 1 && paths2.size == 1) {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperiment.kt
@@ -43,7 +43,7 @@ data class SpanFitInformation(
         val build: String,
         val data: List<TC>,
         val labels: List<String>,
-        val fragment: Int?,
+        val fragment: Optional<Int>,
         val binSize: Int,
         val chromosomesSizes: LinkedHashMap<String, Int>,
         val version: Int
@@ -53,7 +53,7 @@ data class SpanFitInformation(
             genomeQuery: GenomeQuery,
             paths: List<Pair<Path, Path?>>,
             labels: List<String>,
-            fragment: Int?,
+            fragment: Optional<Int>,
             binSize: Int
     ): this(
         genomeQuery.build,
@@ -206,7 +206,7 @@ abstract class SpanModelFitExperiment<out Model : ClassificationModel, State : A
         externalGenomeQuery: GenomeQuery,
         paths: List<Pair<Path, Path?>>,
         labels: List<String>,
-        fragment: Int?,
+        fragment: Optional<Int>,
         val binSize: Int,
         modelFitter: Fitter<Model>,
         modelClass: Class<Model>,
@@ -216,7 +216,8 @@ abstract class SpanModelFitExperiment<out Model : ClassificationModel, State : A
         private val fixedModelPath: Path? = null
 ) : ModelFitExperiment<Model, State>(
     createEffectiveQueries(externalGenomeQuery, paths, labels, fragment, binSize, unique),
-    modelFitter, modelClass, availableStates) {
+    modelFitter, modelClass, availableStates
+) {
 
     val results: SpanFitResults by lazy {
         getOrLoadResults()
@@ -338,7 +339,7 @@ abstract class SpanModelFitExperiment<out Model : ClassificationModel, State : A
                 genomeQuery: GenomeQuery,
                 paths: List<Pair<Path, Path?>>,
                 labels: List<String>,
-                fragment: Int?,
+                fragment: Optional<Int>,
                 binSize: Int,
                 unique: Boolean = true
         ): Pair<GenomeQuery, Query<Chromosome, DataFrame>> {
@@ -360,8 +361,8 @@ abstract class SpanModelFitExperiment<out Model : ClassificationModel, State : A
                 throw IllegalStateException(errMessage)
             }
             val effectiveGenomeQuery = GenomeQuery(
-                    genomeQuery.genome,
-                    *nonEmptyChromosomes.map { it.name }.toTypedArray()
+                genomeQuery.genome,
+                *nonEmptyChromosomes.map { it.name }.toTypedArray()
             )
             return effectiveGenomeQuery to object : CachingQuery<Chromosome, DataFrame>() {
                 val scores = paths.map {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperiment.kt
@@ -161,7 +161,7 @@ data class SpanFitInformation(
 
 
         private val GSON = GsonBuilder()
-                .registerTypeAdapter(object : TypeToken<Optional<Int>>() {}.type, FragmentTypeAdapter)
+                .registerTypeAdapter(object : TypeToken<Fragment>() {}.type, FragmentTypeAdapter)
                 .setPrettyPrinting()
                 .setFieldNamingStrategy(GSONUtil.NO_MY_UNDESCORE_NAMING_STRATEGY)
                 .create()
@@ -211,7 +211,7 @@ data class SpanFitResults(
 
 
 /**
- * A generic class for [SPAN] (Semi-supervised Peak Analyzer) - tool for analyzing and comparing ChIP-Seq data.
+ * A generic class for Span (Semi-supervised Peak Analyzer) - tool for analyzing and comparing ChIP-Seq data.
  * Both procedures rely on the Zero Inflated Negative Binomial Restricted Algorithm.
  *
  * It is implemented as [ModelFitExperiment] with different [ClassificationModel] models.

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperiment.kt
@@ -70,7 +70,7 @@ data class SpanFitInformation(
         VERSION
     )
 
-    fun genomeQuery(): GenomeQuery = GenomeQuery(Genome[build], *chromosomesSizes.keys.toTypedArray())
+    fun genomeQuery(): GenomeQuery = GenomeQuery(Genome[build, chromosomesSizes], *chromosomesSizes.keys.toTypedArray())
 
     internal fun checkGenome(genome: Genome) {
         check(this.build == genome.build) {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanPeakCallingExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanPeakCallingExperiment.kt
@@ -14,6 +14,7 @@ import org.jetbrains.bio.statistics.hmm.MLFreeNBHMM
 import org.jetbrains.bio.statistics.hypothesis.NullHypothesis
 import org.jetbrains.bio.statistics.state.ZLH
 import java.nio.file.Path
+import java.util.*
 
 /**
  * @author Alexey Dievsky
@@ -22,7 +23,7 @@ import java.nio.file.Path
 class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
         genomeQuery: GenomeQuery,
         paths: List<Pair<Path, Path?>>,
-        fragment: Int?,
+        fragment: Optional<Int>,
         binSize: Int,
         modelFitter: Fitter<Model>,
         modelClass: Class<Model>,
@@ -42,7 +43,7 @@ class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
             paths: Pair<Path, Path?>,
             modelFitter: Fitter<Model>,
             modelClass: Class<Model>,
-            fragment: Int?,
+            fragment: Optional<Int>,
             binSize: Int,
             states: Array<State>,
             nullHypothesis: NullHypothesis<State>,
@@ -74,7 +75,7 @@ class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
                 genomeQuery: GenomeQuery,
                 paths: List<Pair<Path, Path?>>,
                 bin: Int,
-                fragment: Int? = null,
+                fragment: Optional<Int> = Optional.empty(),
                 unique: Boolean = true,
                 fixedModelPath: Path? = null
         ): SpanPeakCallingExperiment<out MLAbstractHMM, ZLH> {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanPeakCallingExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanPeakCallingExperiment.kt
@@ -58,7 +58,7 @@ class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
     override val id: String =
             reduceIds(
                 paths.flatMap { listOfNotNull(it.first, it.second) }.map { it.stemGz } +
-                        listOfNotNull(fragment, binSize).map { it.toString() })
+                        listOfNotNull(fragment.orElse(null), binSize).map { it.toString() })
 
 
     companion object {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanPeakCallingExperiment.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/fit/SpanPeakCallingExperiment.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.bio.experiments.fit
 
+import org.jetbrains.bio.coverage.AutoFragment
+import org.jetbrains.bio.coverage.Fragment
 import org.jetbrains.bio.dataframe.DataFrame
 import org.jetbrains.bio.genome.GenomeQuery
 import org.jetbrains.bio.query.reduceIds
@@ -14,7 +16,6 @@ import org.jetbrains.bio.statistics.hmm.MLFreeNBHMM
 import org.jetbrains.bio.statistics.hypothesis.NullHypothesis
 import org.jetbrains.bio.statistics.state.ZLH
 import java.nio.file.Path
-import java.util.*
 
 /**
  * @author Alexey Dievsky
@@ -23,7 +24,7 @@ import java.util.*
 class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
         genomeQuery: GenomeQuery,
         paths: List<Pair<Path, Path?>>,
-        fragment: Optional<Int>,
+        fragment: Fragment,
         binSize: Int,
         modelFitter: Fitter<Model>,
         modelClass: Class<Model>,
@@ -43,7 +44,7 @@ class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
             paths: Pair<Path, Path?>,
             modelFitter: Fitter<Model>,
             modelClass: Class<Model>,
-            fragment: Optional<Int>,
+            fragment: Fragment,
             binSize: Int,
             states: Array<State>,
             nullHypothesis: NullHypothesis<State>,
@@ -58,7 +59,7 @@ class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
     override val id: String =
             reduceIds(
                 paths.flatMap { listOfNotNull(it.first, it.second) }.map { it.stemGz } +
-                        listOfNotNull(fragment.orElse(null), binSize).map { it.toString() })
+                        listOfNotNull(fragment.nullableInt, binSize).map { it.toString() })
 
 
     companion object {
@@ -75,7 +76,7 @@ class SpanPeakCallingExperiment<Model : ClassificationModel, State : Any>(
                 genomeQuery: GenomeQuery,
                 paths: List<Pair<Path, Path?>>,
                 bin: Int,
-                fragment: Optional<Int> = Optional.empty(),
+                fragment: Fragment = AutoFragment,
                 unique: Boolean = true,
                 fixedModelPath: Path? = null
         ): SpanPeakCallingExperiment<out MLAbstractHMM, ZLH> {

--- a/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Labels.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Labels.kt
@@ -81,8 +81,8 @@ data class PeakAnnotation(override val location: Location,
             return format.parse(labelPath) { it.toList() }.map {
                 val e = it.unpackRegularFields(format)
                 val type = PeakAnnotationType.from(e.name)
-                requireNotNull("Unknown type: $type")
-                PeakAnnotation(e.toLocation(genome), type!!)
+                requireNotNull(type) { "Unknown type: ${e.name}" }
+                PeakAnnotation(e.toLocation(genome), type)
             }
         }
     }

--- a/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Tools2TuneSpan.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Tools2TuneSpan.kt
@@ -16,6 +16,7 @@ import org.jetbrains.bio.statistics.ClassificationModel
 import org.jetbrains.bio.tools.ToolsChipSeqWashu
 import org.jetbrains.bio.util.*
 import java.nio.file.Path
+import java.util.*
 import java.util.stream.Collectors
 
 object Span : Tool2Tune<Pair<Double, Int>>() {
@@ -65,7 +66,7 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
         labelledTracks.forEach { (cellId, replicate, trackPath, labelsPath) ->
             val peakCallingExperiment = SpanPeakCallingExperiment.getExperiment(configuration.genomeQuery,
                 listOf(trackPath to inputPath),
-                DEFAULT_BIN, null
+                DEFAULT_BIN, Optional.empty()
             )
 
             if (saveAllPeaks) {
@@ -241,9 +242,11 @@ object SpanReplicated : ReplicatedTool2Tune<Pair<Double, Int>>() {
                 .filter { it.key.dataType.toDataType() == DataType.CHIP_SEQ && ChipSeqTarget.isInput(it.key.dataType) }
                 .flatMap { it.value }.map { it.second.path }.firstOrNull()
 
-        val replicatedPeakCallingExperiment = SpanPeakCallingExperiment.getExperiment(configuration.genomeQuery,
+        val replicatedPeakCallingExperiment = SpanPeakCallingExperiment.getExperiment(
+            configuration.genomeQuery,
             labelledTracks.map(LabelledTrack::trackPath).map { it to inputPath },
-            DEFAULT_BIN, null)
+            DEFAULT_BIN, Optional.empty()
+        )
 
         if (saveAllPeaks) {
             PeakCallerTuning.LOG.info("Saving all $id peaks $target")

--- a/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Tools2TuneSpan.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Tools2TuneSpan.kt
@@ -6,14 +6,12 @@ import org.jetbrains.bio.coverage.AutoFragment
 import org.jetbrains.bio.coverage.removeDuplicates
 import org.jetbrains.bio.dataset.*
 import org.jetbrains.bio.experiments.fit.SpanFitResults
-import org.jetbrains.bio.experiments.fit.SpanModelFitExperiment
 import org.jetbrains.bio.experiments.fit.SpanPeakCallingExperiment
 import org.jetbrains.bio.genome.GenomeQuery
 import org.jetbrains.bio.genome.containers.LocationsMergingList
 import org.jetbrains.bio.io.BedFormat
 import org.jetbrains.bio.span.getPeaks
 import org.jetbrains.bio.span.savePeaks
-import org.jetbrains.bio.statistics.ClassificationModel
 import org.jetbrains.bio.tools.ToolsChipSeqWashu
 import org.jetbrains.bio.util.*
 import java.nio.file.Path
@@ -49,10 +47,10 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
     override fun defaultParams(uli: Boolean) = DEFAULT_FDR to DEFAULT_GAP
 
     override fun tune(configuration: DataConfig,
-                      path: Path,
-                      target: String,
-                      useInput: Boolean,
-                      saveAllPeaks: Boolean) {
+            path: Path,
+            target: String,
+            useInput: Boolean,
+            saveAllPeaks: Boolean) {
         if (!checkTuningRequired(configuration, path, target, useInput)) {
             return
         }
@@ -77,7 +75,7 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
                     val peaksPath = folder / transform(parameter) / fileName(cellId, replicate, target, parameter)
                     peaksPath.checkOrRecalculate(ignoreEmptyFile = true) { (path) ->
                         savePeaks(peakCallingExperiment.results.getPeaks(configuration.genomeQuery,
-                                parameter.first, parameter.second), path)
+                            parameter.first, parameter.second), path)
                     }
                     progress.report()
                 }
@@ -86,10 +84,10 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
 
             PeakCallerTuning.LOG.info("Tuning $id $target $cellId $replicate peaks")
             val labels = PeakAnnotation.loadLabels(
-                    labelsPath, configuration.genomeQuery.genome
+                labelsPath, configuration.genomeQuery.genome
             )
             val (labelErrorsGrid, index) =
-                    tune(peakCallingExperiment, labels, "$id $target $cellId $replicate", parameters)
+                    tune(peakCallingExperiment.results, labels, "$id $target $cellId $replicate", parameters)
 
 
             PeakCallerTuning.LOG.info("Saving $id $target $cellId $replicate optimal peaks to $folder")
@@ -97,8 +95,8 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
             val optimalParameters = parameters[index]
             val optimalPeaksPath = folder / fileName(cellId, replicate, target, optimalParameters)
             savePeaks(peakCallingExperiment.results.getPeaks(configuration.genomeQuery,
-                    optimalParameters.first, optimalParameters.second),
-                    optimalPeaksPath)
+                optimalParameters.first, optimalParameters.second),
+                optimalPeaksPath)
 
             // Compute _rip.sh file
             ToolsChipSeqWashu().runRip(removeDuplicates(trackPath), optimalPeaksPath)
@@ -114,31 +112,32 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
         saveGrid(path, target, useInput)
     }
 
-    fun <Model : ClassificationModel, State : Any>
-            tune(experiment: SpanModelFitExperiment<Model, State>,
-                 labels: List<PeakAnnotation>,
-                 id: String,
-                 parameters: List<Pair<Double, Int>>,
-                 cancellableState: CancellableState = CancellableState.current()): Pair<List<LabelErrors>, Int> {
-        val results = experiment.results
+    fun tune(
+            results: SpanFitResults,
+            labels: List<PeakAnnotation>,
+            id: String,
+            parameters: List<Pair<Double, Int>>,
+            cancellableState: CancellableState = CancellableState.current()
+    ): Pair<List<LabelErrors>, Int> {
         MultitaskProgress.addTask(id, parameters.size.toLong())
-        val tuneResults = tune(results, experiment.genomeQuery, labels, id, parameters, cancellableState)
+        val tuneResults = tune(results, results.fitInfo.genomeQuery(), labels, id, parameters, cancellableState)
         MultitaskProgress.finishTask(id)
         return tuneResults
     }
 
 
-    fun tune(results: SpanFitResults,
-             genomeQuery: GenomeQuery,
-             labels: List<PeakAnnotation>,
-             id: String,
-             parameters: List<Pair<Double, Int>>,
-             cancellableState: CancellableState = CancellableState.current())
-            : Pair<List<LabelErrors>, Int> {
+    fun tune(
+            results: SpanFitResults,
+            genomeQuery: GenomeQuery,
+            labels: List<PeakAnnotation>,
+            id: String,
+            parameters: List<Pair<Double, Int>>,
+            cancellableState: CancellableState = CancellableState.current()
+    ): Pair<List<LabelErrors>, Int> {
 
         val labeledGenomeQuery = GenomeQuery(
-                genomeQuery.genome,
-                *labels.map { it.location.chromosome.name }.distinct().toTypedArray()
+            genomeQuery.genome,
+            *labels.map { it.location.chromosome.name }.distinct().toTypedArray()
         )
         // Parallelism is OK here:
         // 1. getPeaks creates BitterSet per each parameters combination of size
@@ -148,8 +147,8 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
             cancellableState.checkCanceled()
             val peaksOnLabeledGenomeQuery = results.getPeaks(labeledGenomeQuery, fdr, gap)
             val errors = computeErrors(labels,
-                    LocationsMergingList.create(
-                            labeledGenomeQuery, peaksOnLabeledGenomeQuery.stream().map { it.location }.iterator())
+                LocationsMergingList.create(
+                    labeledGenomeQuery, peaksOnLabeledGenomeQuery.stream().map { it.location }.iterator())
             )
             MultitaskProgress.reportTask(id)
             errors
@@ -226,10 +225,10 @@ object SpanReplicated : ReplicatedTool2Tune<Pair<Double, Int>>() {
     }
 
     override fun tune(configuration: DataConfig,
-                      path: Path,
-                      target: String,
-                      useInput: Boolean,
-                      saveAllPeaks: Boolean) {
+            path: Path,
+            target: String,
+            useInput: Boolean,
+            saveAllPeaks: Boolean) {
 
         if (!checkTuningReplicatedRequired(path, target, useInput)) {
             return
@@ -257,8 +256,8 @@ object SpanReplicated : ReplicatedTool2Tune<Pair<Double, Int>>() {
                 val peaksPath = folder / transform(parameter) / fileName(target, parameter)
                 peaksPath.checkOrRecalculate(ignoreEmptyFile = true) { (p) ->
                     savePeaks(replicatedPeakCallingExperiment.results.getPeaks(configuration.genomeQuery,
-                            parameter.first, parameter.second),
-                            p)
+                        parameter.first, parameter.second),
+                        p)
                 }
                 progress.report()
             }
@@ -268,12 +267,12 @@ object SpanReplicated : ReplicatedTool2Tune<Pair<Double, Int>>() {
         PeakCallerTuning.LOG.info("Tuning $id peaks $target")
         val labelsPath = labelledTracks.first().labelPath
         val labels = PeakAnnotation.loadLabels(labelsPath, configuration.genomeQuery.genome)
-        val (labelErrorsGrid, index) = Span.tune(replicatedPeakCallingExperiment, labels, target, parameters)
+        val (labelErrorsGrid, index) = Span.tune(replicatedPeakCallingExperiment.results, labels, target, parameters)
 
         PeakCallerTuning.LOG.info("Saving $target optimal $id peaks to $folder")
         savePeaks(replicatedPeakCallingExperiment.results.getPeaks(configuration.genomeQuery,
-                parameters[index].first, parameters[index].second),
-                folder / fileName(target, parameters[index]))
+            parameters[index].first, parameters[index].second),
+            folder / fileName(target, parameters[index]))
 
         val results = TuningResults()
         labelErrorsGrid.forEachIndexed { i, error ->

--- a/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Tools2TuneSpan.kt
+++ b/src/main/kotlin/org/jetbrains/bio/experiments/tuning/Tools2TuneSpan.kt
@@ -2,6 +2,7 @@ package org.jetbrains.bio.experiments.tuning
 
 import com.google.common.primitives.Shorts
 import kotlinx.support.jdk7.use
+import org.jetbrains.bio.coverage.AutoFragment
 import org.jetbrains.bio.coverage.removeDuplicates
 import org.jetbrains.bio.dataset.*
 import org.jetbrains.bio.experiments.fit.SpanFitResults
@@ -16,7 +17,6 @@ import org.jetbrains.bio.statistics.ClassificationModel
 import org.jetbrains.bio.tools.ToolsChipSeqWashu
 import org.jetbrains.bio.util.*
 import java.nio.file.Path
-import java.util.*
 import java.util.stream.Collectors
 
 object Span : Tool2Tune<Pair<Double, Int>>() {
@@ -66,7 +66,7 @@ object Span : Tool2Tune<Pair<Double, Int>>() {
         labelledTracks.forEach { (cellId, replicate, trackPath, labelsPath) ->
             val peakCallingExperiment = SpanPeakCallingExperiment.getExperiment(configuration.genomeQuery,
                 listOf(trackPath to inputPath),
-                DEFAULT_BIN, Optional.empty()
+                DEFAULT_BIN, AutoFragment
             )
 
             if (saveAllPeaks) {
@@ -245,7 +245,7 @@ object SpanReplicated : ReplicatedTool2Tune<Pair<Double, Int>>() {
         val replicatedPeakCallingExperiment = SpanPeakCallingExperiment.getExperiment(
             configuration.genomeQuery,
             labelledTracks.map(LabelledTrack::trackPath).map { it to inputPath },
-            DEFAULT_BIN, Optional.empty()
+            DEFAULT_BIN, AutoFragment
         )
 
         if (saveAllPeaks) {

--- a/src/main/kotlin/org/jetbrains/bio/span/CoverageScoresQuery.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/CoverageScoresQuery.kt
@@ -24,7 +24,7 @@ class CoverageScoresQuery(
     override val id: String
         get() = reduceIds(
             listOfNotNull(
-                treatmentPath.stemGz, controlPath?.stemGz, fragment, binSize,
+                treatmentPath.stemGz, controlPath?.stemGz, fragment.orElse(null), binSize,
                 if (!unique) "keepdup" else null
             ).map { it.toString() }
         )

--- a/src/main/kotlin/org/jetbrains/bio/span/CoverageScoresQuery.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/CoverageScoresQuery.kt
@@ -7,17 +7,15 @@ import org.jetbrains.bio.genome.GenomeQuery
 import org.jetbrains.bio.genome.Strand
 import org.jetbrains.bio.genome.containers.GenomeMap
 import org.jetbrains.bio.genome.containers.genomeMap
-import org.jetbrains.bio.query.CachingQuery
-import org.jetbrains.bio.query.ReadsQuery
-import org.jetbrains.bio.query.reduceIds
-import org.jetbrains.bio.query.stemGz
+import org.jetbrains.bio.query.*
 import java.nio.file.Path
+import java.util.*
 
 class CoverageScoresQuery(
         val genomeQuery: GenomeQuery,
         private val treatmentPath: Path,
         private val controlPath: Path?,
-        val fragment: Int?,
+        val fragment: Optional<Int>,
         val binSize: Int,
         val unique: Boolean = true
 ): CachingQuery<Chromosome, IntArray>() {
@@ -33,7 +31,7 @@ class CoverageScoresQuery(
 
     override val description: String
         get() = "Treatment: $treatmentPath, Control: $controlPath, " +
-                "Fragment: $fragment, Bin: $binSize, Keep-dup: ${!unique}"
+                "Fragment: ${fragment.fragmentToString()}, Bin: $binSize, Keep-dup: ${!unique}"
 
     override fun getUncached(input: Chromosome): IntArray {
         return scores[input]

--- a/src/main/kotlin/org/jetbrains/bio/span/CoverageScoresQuery.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/CoverageScoresQuery.kt
@@ -1,21 +1,24 @@
 package org.jetbrains.bio.span
 
 import org.jetbrains.bio.coverage.Coverage
+import org.jetbrains.bio.coverage.Fragment
 import org.jetbrains.bio.dataframe.DataFrame
 import org.jetbrains.bio.genome.Chromosome
 import org.jetbrains.bio.genome.GenomeQuery
 import org.jetbrains.bio.genome.Strand
 import org.jetbrains.bio.genome.containers.GenomeMap
 import org.jetbrains.bio.genome.containers.genomeMap
-import org.jetbrains.bio.query.*
+import org.jetbrains.bio.query.CachingQuery
+import org.jetbrains.bio.query.ReadsQuery
+import org.jetbrains.bio.query.reduceIds
+import org.jetbrains.bio.query.stemGz
 import java.nio.file.Path
-import java.util.*
 
 class CoverageScoresQuery(
         val genomeQuery: GenomeQuery,
         private val treatmentPath: Path,
         private val controlPath: Path?,
-        val fragment: Optional<Int>,
+        val fragment: Fragment,
         val binSize: Int,
         val unique: Boolean = true
 ): CachingQuery<Chromosome, IntArray>() {
@@ -24,14 +27,14 @@ class CoverageScoresQuery(
     override val id: String
         get() = reduceIds(
             listOfNotNull(
-                treatmentPath.stemGz, controlPath?.stemGz, fragment.orElse(null), binSize,
-                if (!unique) "keepdup" else null
+                treatmentPath.stemGz, controlPath?.stemGz, fragment.nullableInt,
+                binSize, if (!unique) "keepdup" else null
             ).map { it.toString() }
         )
 
     override val description: String
         get() = "Treatment: $treatmentPath, Control: $controlPath, " +
-                "Fragment: ${fragment.fragmentToString()}, Bin: $binSize, Keep-dup: ${!unique}"
+                "Fragment: $fragment, Bin: $binSize, Keep-dup: ${!unique}"
 
     override fun getUncached(input: Chromosome): IntArray {
         return scores[input]

--- a/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
@@ -334,7 +334,7 @@ compare                         Differential peak calling mode, experimental
                 configurePaths(workingDir, chromSizesPath)
                 val genome = Genome[chromSizesPath]
                 LOG.info("GENOME: ${genome.build}")
-                LOG.info("FRAGMENT: $fragment")
+                LOG.info("FRAGMENT: ${fragment.fragmentToString()}")
                 LOG.info("BIN: $bin")
                 LOG.info("FDR: $fdr")
                 LOG.info("GAP: $gap")

--- a/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
@@ -600,7 +600,9 @@ compare                         Differential peak calling mode, experimental
      * Creates the peak calling experiment using the supplied command line arguments.
      * Logs the progress.
      */
-    private fun constructPeakCallingExperiment(options: OptionSet): SpanPeakCallingExperiment<out MLAbstractHMM, ZLH> {
+    private fun constructPeakCallingExperiment(
+            options: OptionSet
+    ): Lazy<SpanPeakCallingExperiment<out MLAbstractHMM, ZLH>> {
         val (_, chromSizesPath) = getAndLogWorkDirAndChromSizes(options)
         // option parser guarantees that chrom.sizes are not null here
         val genomeQuery = GenomeQuery(Genome[chromSizesPath!!])
@@ -610,7 +612,7 @@ compare                         Differential peak calling mode, experimental
         val fragment = getFragment(options, log = true)
         val unique = getUnique(options, log = true)
         val modelPath = options.valueOf("model") as Path?
-        return SpanPeakCallingExperiment.getExperiment(genomeQuery, data, bin, fragment, unique, modelPath)
+        return lazy { SpanPeakCallingExperiment.getExperiment(genomeQuery, data, bin, fragment, unique, modelPath) }
     }
 
     /**
@@ -631,10 +633,10 @@ compare                         Differential peak calling mode, experimental
                 )
                 val results = SpanModelFitExperiment.loadResults(tarPath = modelPath)
                 checkFitInformation(options, results.fitInfo)
-                return lazy { results }
+                return lazyOf(results)
             }
         }
         val experiment = constructPeakCallingExperiment(options)
-        return lazy { experiment.results }
+        return lazy { experiment.value.results }
     }
 }

--- a/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
@@ -422,6 +422,9 @@ compare                         Differential peak calling mode, experimental
                     .withRequiredArg()
                     .ofType(Int::class.java)
             acceptsAll(listOf("k", "keep-dup"), "Keep duplicates")
+                    .withOptionalArg()
+                    .ofType(Boolean::class.java)
+                    .defaultsTo(true)
         }
     }
 
@@ -497,7 +500,7 @@ compare                         Differential peak calling mode, experimental
     }
 
     private fun getUnique(options: OptionSet, fitInformation: SpanFitInformation? = null, log: Boolean = false): Boolean {
-        val commandLineKeepDup = options.valueOf("keep-dup") as Boolean?
+        val commandLineKeepDup = if ("keep-dup" in options) options.valueOf("keep-dup") as Boolean else null
         check(fitInformation == null || commandLineKeepDup == null || commandLineKeepDup == !fitInformation.unique) {
             "Stored keep-dup flag ${!fitInformation!!.unique} differs from the command line argument $commandLineKeepDup"
         }

--- a/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/SpanCLA.kt
@@ -246,8 +246,8 @@ compare                         Differential peak calling mode, experimental
                 val treatmentPaths2 = options.valuesOf("treatment2") as List<Path>
                 val controlPaths1 = options.valuesOf("control1") as List<Path>?
                 val controlPaths2 = options.valuesOf("control2") as List<Path>?
-                val fragment = options.valueOf("fragment") as Fragment
-                val bin = options.valueOf("bin") as Int
+                val fragment = getFragment(options, null, log = false)
+                val bin = getBin(options, null, log = false)
                 val gap = options.valueOf("gap") as Int
                 val fdr = options.valueOf("fdr") as Double
                 val peaksPath = options.valueOf("peaks") as Path?

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
@@ -69,7 +69,7 @@ class SpanFitInformationTest {
   "labels": [
     "treatment_control"
   ],
-  "fragment": 100,
+  "fragment": "100",
   "bin_size": 200,
   "chromosomes_sizes": {
     "chr1": 10000000,
@@ -78,7 +78,7 @@ class SpanFitInformationTest {
     "chrM": 1000000,
     "chrX": 1000000
   },
-  "version": 1
+  "version": 2
 }""".trim().lines(), path.bufferedReader().lines().collect(Collectors.toList()))
                 }
                 assertEquals(listOf("chr1", "chr2", "chr3", "chrM", "chrX"), info.chromosomesSizes.keys.toList())
@@ -103,7 +103,7 @@ class SpanFitInformationTest {
   "labels": [
     "treatment_control"
   ],
-  "fragment": null,
+  "fragment": "auto",
   "bin_size": 200,
   "chromosomes_sizes": {
     "chr1": 10000000,
@@ -112,7 +112,7 @@ class SpanFitInformationTest {
     "chrM": 1000000,
     "chrX": 1000000
   },
-  "version": 1
+  "version": 2
 }""")
             }
             assertEquals(info, SpanFitInformation.load(path))
@@ -122,17 +122,17 @@ class SpanFitInformationTest {
     @Test
     fun checkVersion() {
         expectedEx.expect(IllegalStateException::class.java)
-        expectedEx.expectMessage("Wrong version: expected: 1, got: 2")
+        expectedEx.expectMessage("Wrong version: expected: 2, got: 3")
         withTempFile("foo", ".tar") { path ->
             path.bufferedWriter().use {
                 it.write("""{
   "build": "to1",
   "data": [],
   "labels": [],
-  "fragment": null,
+  "fragment": "auto",
   "bin_size": 200,
   "chromosomes_sizes": {},
-  "version": 2
+  "version": 3
 }""")
             }
             SpanFitInformation.load(path)
@@ -163,4 +163,4 @@ internal operator fun SpanFitInformation.Companion.invoke(
         labels: List<String>,
         fragment: Int,
         binSize: Int
-    ): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, Optional.of(fragment), binSize)
+): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, Optional.of(fragment), binSize)

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
+import java.nio.file.Path
 import java.util.*
 import java.util.stream.Collectors
 
@@ -30,13 +31,16 @@ class SpanFitInformationTest {
     fun checkWrongBuild() {
         expectedEx.expect(IllegalStateException::class.java)
         expectedEx.expectMessage("Wrong genome build, expected: hg19, got: to1")
-        SpanFitInformation("hg19", emptyList(), emptyList(), 100, 200, LinkedHashMap(), 1).checkGenome(Genome["to1"])
+        SpanFitInformation(
+            "hg19", emptyList(), emptyList(), Optional.of(100), 200, LinkedHashMap(), 1
+        ).checkGenome(Genome["to1"])
     }
 
     @Test
     fun checkGenomeQueryOrder() {
-        SpanFitInformation(GenomeQuery(Genome["to1"], "chr1", "chr2"), emptyList(), emptyList(), 100, 200)
-                .checkGenome(Genome["to1"])
+        SpanFitInformation(
+            GenomeQuery(Genome["to1"], "chr1", "chr2"), emptyList(), emptyList(), 100, 200
+        ).checkGenome(Genome["to1"])
     }
 
 
@@ -84,7 +88,9 @@ class SpanFitInformationTest {
 
     @Test
     fun checkLoad() {
-        val info = SpanFitInformation(gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), null, 200)
+        val info = SpanFitInformation(
+            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), Optional.empty(), 200
+        )
         withTempFile("foo", ".tar") { path ->
             path.bufferedWriter().use {
                 it.write("""{
@@ -148,3 +154,13 @@ class SpanFitInformationTest {
     }
 }
 
+/**
+ * Simplified instance construction for tests.
+ */
+internal operator fun SpanFitInformation.Companion.invoke(
+        genomeQuery: GenomeQuery,
+        paths: List<Pair<Path, Path?>>,
+        labels: List<String>,
+        fragment: Int,
+        binSize: Int
+    ): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, Optional.of(fragment), binSize)

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.bio.experiments.fit
 
+import org.jetbrains.bio.coverage.AutoFragment
+import org.jetbrains.bio.coverage.FixedFragment
 import org.jetbrains.bio.genome.Genome
 import org.jetbrains.bio.genome.GenomeQuery
 import org.jetbrains.bio.util.bufferedReader
@@ -32,7 +34,7 @@ class SpanFitInformationTest {
         expectedEx.expect(IllegalStateException::class.java)
         expectedEx.expectMessage("Wrong genome build, expected: hg19, got: to1")
         SpanFitInformation(
-            "hg19", emptyList(), emptyList(), Optional.of(100), 200, LinkedHashMap(), 1
+            "hg19", emptyList(), emptyList(), FixedFragment(100), 200, LinkedHashMap(), 1
         ).checkGenome(Genome["to1"])
     }
 
@@ -89,7 +91,7 @@ class SpanFitInformationTest {
     @Test
     fun checkLoad() {
         val info = SpanFitInformation(
-            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), Optional.empty(), 200
+            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), AutoFragment, 200
         )
         withTempFile("foo", ".tar") { path ->
             path.bufferedWriter().use {
@@ -163,4 +165,4 @@ internal operator fun SpanFitInformation.Companion.invoke(
         labels: List<String>,
         fragment: Int,
         binSize: Int
-): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, Optional.of(fragment), binSize)
+): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, FixedFragment(fragment), binSize)

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
@@ -34,21 +34,21 @@ class SpanFitInformationTest {
         expectedEx.expect(IllegalStateException::class.java)
         expectedEx.expectMessage("Wrong genome build, expected: hg19, got: to1")
         SpanFitInformation(
-            "hg19", emptyList(), emptyList(), FixedFragment(100), 200, LinkedHashMap(), 1
+            "hg19", emptyList(), emptyList(), FixedFragment(100), true, 200, LinkedHashMap(), 1
         ).checkGenome(Genome["to1"])
     }
 
     @Test
     fun checkGenomeQueryOrder() {
         SpanFitInformation(
-            GenomeQuery(Genome["to1"], "chr1", "chr2"), emptyList(), emptyList(), 100, 200
+            GenomeQuery(Genome["to1"], "chr1", "chr2"), emptyList(), emptyList(), 100, true,  200
         ).checkGenome(Genome["to1"])
     }
 
 
     @Test
     fun checkOf() {
-        val of = SpanFitInformation(gq, emptyList(), emptyList(), 100, 200)
+        val of = SpanFitInformation(gq, emptyList(), emptyList(), 100, true, 200)
         assertEquals(listOf("chr1", "chr2", "chr3", "chrM", "chrX"), of.chromosomesSizes.keys.toList())
     }
 
@@ -56,7 +56,7 @@ class SpanFitInformationTest {
     fun checkSave() {
         withTempFile("treatment", ".bam") { t ->
             withTempFile("control", ".bam") { c ->
-                val info = SpanFitInformation(gq, listOf(t to c), listOf("treatment_control"), 100, 200)
+                val info = SpanFitInformation(gq, listOf(t to c), listOf("treatment_control"), 100, true, 200)
                 withTempFile("foo", ".tar") { path ->
                     info.save(path)
                     // Escape Windows separators here
@@ -91,7 +91,7 @@ class SpanFitInformationTest {
     @Test
     fun checkLoad() {
         val info = SpanFitInformation(
-            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), AutoFragment, 200
+            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), AutoFragment, true, 200
         )
         withTempFile("foo", ".tar") { path ->
             path.bufferedWriter().use {
@@ -143,13 +143,13 @@ class SpanFitInformationTest {
 
     @Test
     fun checkIndices() {
-        val info = SpanFitInformation(gq, emptyList(), emptyList(), 100, 200)
+        val info = SpanFitInformation(gq, emptyList(), emptyList(), 100, true, 200)
         assertEquals(50000 to 55000, info.getChromosomesIndices(chr2))
     }
 
     @Test
     fun checkOffsets() {
-        val info = SpanFitInformation(gq, emptyList(), emptyList(), 100, 200)
+        val info = SpanFitInformation(gq, emptyList(), emptyList(), 100, true, 200)
         assertEquals(listOf(0, 200, 400, 600, 800), info.offsets(chr2).take(5))
         assertEquals(5000, chr2.length / 200)
         assertEquals(5000, info.offsets(chr2).size)
@@ -164,5 +164,6 @@ internal operator fun SpanFitInformation.Companion.invoke(
         paths: List<Pair<Path, Path?>>,
         labels: List<String>,
         fragment: Int,
+        unique: Boolean,
         binSize: Int
-): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, FixedFragment(fragment), binSize)
+): SpanFitInformation = SpanFitInformation(genomeQuery, paths, labels, FixedFragment(fragment), unique, binSize)

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanFitInformationTest.kt
@@ -56,7 +56,7 @@ class SpanFitInformationTest {
     fun checkSave() {
         withTempFile("treatment", ".bam") { t ->
             withTempFile("control", ".bam") { c ->
-                val info = SpanFitInformation(gq, listOf(t to c), listOf("treatment_control"), 100, true, 200)
+                val info = SpanFitInformation(gq, listOf(t to c), listOf("treatment_control"), 100, false, 200)
                 withTempFile("foo", ".tar") { path ->
                     info.save(path)
                     // Escape Windows separators here
@@ -72,6 +72,7 @@ class SpanFitInformationTest {
     "treatment_control"
   ],
   "fragment": "100",
+  "unique": false,
   "bin_size": 200,
   "chromosomes_sizes": {
     "chr1": 10000000,
@@ -91,7 +92,7 @@ class SpanFitInformationTest {
     @Test
     fun checkLoad() {
         val info = SpanFitInformation(
-            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), AutoFragment, true, 200
+            gq, listOf("path_to_file".toPath() to null), listOf("treatment_control"), AutoFragment, false, 200
         )
         withTempFile("foo", ".tar") { path ->
             path.bufferedWriter().use {
@@ -106,6 +107,7 @@ class SpanFitInformationTest {
     "treatment_control"
   ],
   "fragment": "auto",
+  "unique": false,
   "bin_size": 200,
   "chromosomes_sizes": {
     "chr1": 10000000,

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperimentTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperimentTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.bio.experiments.fit
 
+import org.jetbrains.bio.coverage.AutoFragment
 import org.jetbrains.bio.genome.Chromosome
 import org.jetbrains.bio.genome.Genome
 import org.jetbrains.bio.genome.GenomeQuery
@@ -28,7 +29,7 @@ class SpanModelFitExperimentTest {
             println("Saved sampled track file: $path")
             val (_, dataQuery) = SpanModelFitExperiment.createEffectiveQueries(
                 GenomeQuery(Genome["to1"]), listOf(path to null),
-                listOf("foo"), Optional.empty(), 200
+                listOf("foo"), AutoFragment, 200
             )
 
             assertTrue(dataQuery.id.startsWith("${path.stemGz}_200_foo#"))
@@ -50,7 +51,7 @@ class SpanModelFitExperimentTest {
                 val (effectiveGenomeQuery, _) =
                         SpanModelFitExperiment.createEffectiveQueries(
                             GenomeQuery(Genome["to1"]),
-                            listOf(path to null), listOf("foo"), Optional.empty(), 200
+                            listOf(path to null), listOf("foo"), AutoFragment, 200
                         )
                 assertEquals("[chr1]", effectiveGenomeQuery.get().map { it.name }.toString())
             }
@@ -71,7 +72,7 @@ class SpanModelFitExperimentTest {
             )
             println("Saved sampled track file: $path")
             val peakCallingExperiment = SpanPeakCallingExperiment.getExperiment(
-                fullGenomeQuery, listOf(path to null), 200, Optional.empty()
+                fullGenomeQuery, listOf(path to null), 200, AutoFragment
             )
             assertTrue(
                 peakCallingExperiment.results.getPeaks(fullGenomeQuery, 0.05, 0).isNotEmpty(),

--- a/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperimentTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/experiments/fit/SpanModelFitExperimentTest.kt
@@ -27,8 +27,8 @@ class SpanModelFitExperimentTest {
             SpanCLALongTest.sampleCoverage(path, GenomeQuery(Genome["to1"]), 200, goodQuality = true)
             println("Saved sampled track file: $path")
             val (_, dataQuery) = SpanModelFitExperiment.createEffectiveQueries(
-                    GenomeQuery(Genome["to1"]), listOf(path to null),
-                    listOf("foo"), null, 200
+                GenomeQuery(Genome["to1"]), listOf(path to null),
+                listOf("foo"), Optional.empty(), 200
             )
 
             assertTrue(dataQuery.id.startsWith("${path.stemGz}_200_foo#"))
@@ -43,13 +43,15 @@ class SpanModelFitExperimentTest {
         // NOTE[oshpynov] we use .bed.gz here for the ease of sampling result save
         withTempFile("track", ".bed.gz") { path ->
             SpanCLALongTest.sampleCoverage(
-                    path, GenomeQuery(Genome["to1"], "chr1"), 200, goodQuality = true
+                path, GenomeQuery(Genome["to1"], "chr1"), 200, goodQuality = true
             )
             println("Saved sampled track file: $path")
             val (out, _) = Logs.captureLoggingOutput {
                 val (effectiveGenomeQuery, _) =
-                        SpanModelFitExperiment.createEffectiveQueries(GenomeQuery(Genome["to1"]),
-                                listOf(path to null), listOf("foo"), null, 200)
+                        SpanModelFitExperiment.createEffectiveQueries(
+                            GenomeQuery(Genome["to1"]),
+                            listOf(path to null), listOf("foo"), Optional.empty(), 200
+                        )
                 assertEquals("[chr1]", effectiveGenomeQuery.get().map { it.name }.toString())
             }
             assertIn("chr2: no reads detected, ignoring", out)
@@ -65,15 +67,15 @@ class SpanModelFitExperimentTest {
         val emptyMaps = genomeMap(effectiveGenomeQuery) { BitSet() }
         withTempFile("track", ".bed.gz") { path ->
             SpanCLALongTest.sampleCoverage(
-                    path, effectiveGenomeQuery, 200, emptyMaps, emptyMaps, goodQuality = true
+                path, effectiveGenomeQuery, 200, emptyMaps, emptyMaps, goodQuality = true
             )
             println("Saved sampled track file: $path")
             val peakCallingExperiment = SpanPeakCallingExperiment.getExperiment(
-                    fullGenomeQuery, listOf(path to null), 200, null
+                fullGenomeQuery, listOf(path to null), 200, Optional.empty()
             )
             assertTrue(
-                    peakCallingExperiment.results.getPeaks(fullGenomeQuery, 0.05, 0).isNotEmpty(),
-                    "Expected peak set not to be empty.")
+                peakCallingExperiment.results.getPeaks(fullGenomeQuery, 0.05, 0).isNotEmpty(),
+                "Expected peak set not to be empty.")
         }
     }
 

--- a/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
@@ -157,7 +157,7 @@ TREATMENT2: $path
 CONTROL2: none
 CHROM.SIZES: $chromsizes
 GENOME: to1
-FRAGMENT: null
+FRAGMENT: auto
 BIN: $BIN
 FDR: $FDR
 GAP: $GAP

--- a/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
@@ -363,6 +363,28 @@ LABELS, FDR, GAP options are ignored.
                     ))
                     assertTrue(modelPath.exists, "Model was not created at $modelPath")
                     assertTrue(modelPath.size.isNotEmpty(), "Model file $modelPath is empty")
+                    val (reloadOut, reloadErr) = Logs.captureLoggingOutput {
+                        SpanCLA.main(arrayOf(
+                            "analyze",
+                            "--workdir", dir.toString(),
+                            "--threads", THREADS.toString(),
+                            "--model", modelPath.toString()
+                        ))
+                    }
+                    assertIn("Completed loading model: $modelPath", reloadOut)
+                    assertEquals("", reloadErr)
+
+                    val (_, invalidErr) = Logs.captureLoggingOutput {
+                        withSystemProperty(JOPTSIMPLE_SUPPRESS_EXIT, "true") {
+                            SpanCLA.main(arrayOf("analyze",
+                                "--workdir", dir.toString(),
+                                "--threads", THREADS.toString(),
+                                "--model", modelPath.toString(),
+                                "--bin", "137"
+                            ))
+                        }
+                    }
+                    assertIn("Stored bin size (200) differs from the command line argument (137)", invalidErr)
                 }
             }
         }

--- a/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
@@ -165,7 +165,7 @@ PEAKS: $peaksPath
 """, out)
                 assertIn("Saved result to $peaksPath", out)
                 // Check model fit has a progress
-                assertIn("] 0.00% (0/250), Elapsed time", out)
+                assertIn("] 0.00% (0/25), Elapsed time", out)
             }
         }
     }

--- a/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
@@ -283,7 +283,7 @@ LABELS, FDR, GAP options are ignored.
                     )
                 }
                 /* we also check that logging was performed normally */
-                val logPath = dir / "logs" / "${reduceIds(listOf(path.stemGz, BIN.toString()))}.log"
+                val logPath = dir / "logs" / "${reduceIds(listOf(path.stemGz, BIN.toString(), "unique"))}.log"
                 assertTrue(logPath.exists, "Log file not found")
                 assertTrue(logPath.size.isNotEmpty(), "Log file is empty")
             }
@@ -312,7 +312,7 @@ LABELS, FDR, GAP options are ignored.
 
                     // Check that log file was created correctly
                     assertTrue(
-                        (dir / "logs" / "${reduceIds(listOf(path.stemGz, control.stemGz, "200"))}.log")
+                        (dir / "logs" / "${reduceIds(listOf(path.stemGz, control.stemGz, "200", "unique"))}.log")
                                 .exists,
                         "Log file not found"
                     )
@@ -490,7 +490,7 @@ LABELS, FDR, GAP options are ignored.
                 }
 
                 // Check correct log file name
-                val logPath = it / "logs" / "${reduceIds(listOf(path.stemGz, BIN.toString()))}.log"
+                val logPath = it / "logs" / "${reduceIds(listOf(path.stemGz, BIN.toString(), "unique"))}.log"
                 assertTrue(logPath.exists, "Log file not found")
                 val log = FileReader(logPath.toFile()).use { it.readText() }
                 val errorMessage = "Model can't be trained on empty coverage, exiting."


### PR DESCRIPTION
0.11.0 release candidate:

- if the model file is present, Span can now call and tune peaks with no further options required
- if the options are nevertheless provided, they're checked against those stored in the model file
- Span recognizes explicit options `--fragment auto` and `--keep-dup false` (previously, the user had to
omit the options to achieve this result)