### PR TITLE
Span peak scores

### DIFF
--- a/src/main/kotlin/org/jetbrains/bio/span/Peaks.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/Peaks.kt
@@ -158,9 +158,13 @@ fun SpanFitResults.getPeaks(
         gap: Int,
         cancellableState: CancellableState? = null
 ): List<Peak> {
+    val coverage = fitInfo.scoresDataFrame()
+    if (coverage.isEmpty()) {
+        SpanFitResults.LOG.debug("No coverage caches present, peak scores won't be computed.")
+    }
     val map = genomeMap(genomeQuery, parallel = true) { chromosome ->
         cancellableState?.checkCanceled()
-        getChromosomePeaks(chromosome, fdr, gap)
+        getChromosomePeaks(chromosome, fdr, gap, coverage[chromosome])
     }
     return genomeQuery.get().flatMap { map[it] }
 }

--- a/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
+++ b/src/test/kotlin/org/jetbrains/bio/span/SpanCLALongTest.kt
@@ -416,6 +416,18 @@ LABELS, FDR, GAP options are ignored.
                 assertIn("Track source: $peaksPath", out)
                 assertIn("FRIP: ", out)
 
+                /* Check that coverage is being generated */
+                val format = BedFormat.from("bed6+3")
+                assertTrue(
+                    format.parse(peaksPath) { parser ->
+                        parser.all { entry ->
+                            val coverage = entry.unpack(6, 3).extraFields?.get(0)
+                            return@all coverage != null && coverage != "0.0"
+                        }
+                    },
+                    "Peak value is reported as 0.0, although the coverage cache is present"
+                )
+
                 // XXX Temporary disabled due to https://github.com/JetBrains-Research/epigenome/issues/1310
                 // Span "signal-to-noise" is very unstable, values differs 2x times for same data
                 // assertIn("Signal to noise: ", out)


### PR DESCRIPTION
Previously, peak value (coverage score / fold change) was only calculated and reported when invoked from JBR.
With this pull request, peak value is reported if Span finds all relevant coverage cache files. If it doesn't, a debug message is logged, and the value is reported as 0.0 (like it is now).

Rationale: if the user obtained just a model file (e.g. by downloading or copying), we should let them call peaks from it, even though there's no access to the coverage data.