### PR TITLE
Use fake process cancelled in order not affect tests

### DIFF
--- a/src/main/kotlin/org/jetbrains/bio/span/SpanCLAAnalyze.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/SpanCLAAnalyze.kt
@@ -182,7 +182,8 @@ object SpanCLAAnalyze {
                             genomeQuery,
                             labels,
                             "",
-                            SpanSemiSupervised.PARAMETERS
+                            SpanSemiSupervised.PARAMETERS,
+                            CancellableState.current()
                         )
                         SpanCLA.LOG.info("Tuning model on the loaded labels complete.")
                         val (optimalFDR, optimalGap) = SpanSemiSupervised.PARAMETERS[optimalIndex]

--- a/src/main/kotlin/org/jetbrains/bio/span/semisupervised/SpanSemiSupervised.kt
+++ b/src/main/kotlin/org/jetbrains/bio/span/semisupervised/SpanSemiSupervised.kt
@@ -35,7 +35,7 @@ object SpanSemiSupervised {
         labels: List<LocationLabel>,
         id: String,
         parameters: List<Pair<Double, Int>>,
-        cancellableState: CancellableState = CancellableState.current()
+        cancellableState: CancellableState
     ): Pair<List<LabelErrors>, Int> {
         val labeledGenomeQuery = GenomeQuery(
             genomeQuery.genome,
@@ -52,7 +52,10 @@ object SpanSemiSupervised {
                 Callable {
                     cancellableState.checkCanceled()
                     val peaksOnLabeledGenomeQuery =
-                        ModelToPeaks.computeChromosomePeaks(results, labeledGenomeQuery, fdr, gap, false)
+                        ModelToPeaks.computeChromosomePeaks(
+                            results, labeledGenomeQuery, fdr, gap, false,
+                            CancellableState.current()
+                        )
                     labelErrorsGrid[index] = computeErrors(
                         labels,
                         LocationsMergingList.create(


### PR DESCRIPTION
Fixes tests that could fails because one of already executed tests haven't cleared the process canclelled flag in thread local. Is part of https://github.com/JetBrains-Research/epigenome/pull/1508